### PR TITLE
Remove unused command caused by API Change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [Unreleased]
+### Added
+- Modify API convert adjusting code caused by 2021-04-22 API response change
+- First release
+
+[Unreleased]: https://github.com/noissefnoc/kafun/compare/..HEAD

--- a/client.go
+++ b/client.go
@@ -153,15 +153,10 @@ func decodeBody(resp *http.Response, out interface{}) error {
 	}
 
 	// APIレスポンスがValidなJSONではないので文字列置換で対応。
-	// レスポンスのイメージは以下で、JSONのkey-valueがクォートされていない
-	// かつ、valueがない場合何も存在しない (今回は `null` に置換する)
-	// [{ KEY11: VALUE11, KEY12: VALUE12 }, { KEY21: VALUE21, KEY22: }]
+	// valueが数値型の場合でもクォートされる、が、null値のときに項目を削除する対応をしていないので
+	//　`null` に置換して存在しないものとして扱う
+	// [{ "KEY11": "VALUE11", "KEY12": "VALUE12" }, { "KEY21": "VALUE21", "KEY22": "" }]
 	str := string(byteArray)
-	str = strings.ReplaceAll(str, `{`, `{"`)
-	str = strings.ReplaceAll(str, `}`, `"}`)
-	str = strings.ReplaceAll(str, `:`, `":"`)
-	str = strings.ReplaceAll(str, `,`, `","`)
-	str = strings.ReplaceAll(str, `}","{`, `},{`)
 	str = strings.ReplaceAll(str, `""`, `null`)
 
 	return json.Unmarshal([]byte(str), out)


### PR DESCRIPTION
2021/04/22のAPIのレスポンス変更でKey-Valueがクォートされることになったのでそこを修正。

See: https://kafun.env.go.jp/apiManual/apiPage4/api-4 for more details

ただし、nullの場合に要素が存在しないではなく、空文字列(長さ0文字列)になっているので、数値型への変換が失敗する問題がまだ残っている。